### PR TITLE
Added try-catch to avoid failure

### DIFF
--- a/Src/Private/Get-AbrVbrLocation.ps1
+++ b/Src/Private/Get-AbrVbrLocation.ps1
@@ -24,10 +24,10 @@ function Get-AbrVbrLocation {
     }
 
     process {
-        if ((Get-VBRLocation).count -gt 0) {
-            Section -Style Heading3 'Geographical Locations' {
-                Paragraph "The following section list geographical locations created in Veeam Backup & Replication."
-                BlankLine
+        Section -Style Heading3 'Geographical Locations' {
+            Paragraph "The following section list geographical locations created in Veeam Backup & Replication."
+            BlankLine
+            try {
                 $OutObj = @()
                 if ((Get-VBRServerSession).Server) {
                     try {
@@ -44,7 +44,7 @@ function Get-AbrVbrLocation {
                     catch {
                         Write-PscriboMessage -IsWarning $_.Exception.Message
                     }
-
+    
                     $TableParams = @{
                         Name = "Location Information - $(((Get-VBRServerSession).Server).ToString().ToUpper().Split(".")[0])"
                         List = $false
@@ -55,6 +55,9 @@ function Get-AbrVbrLocation {
                     }
                     $OutObj | Table @TableParams
                 }
+            }
+            catch {
+                Write-PscriboMessage -IsWarning $_.Exception.Message
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added Try-Catch to avoid failure
## Description
<!--- Describe your changes in detail -->
In the private script Get-AbrVbrLocation there is no error handling for the case, if no locations exists.
I added a try catch to avoid script determation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Since your repository forked too, i can't open an issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I couldn't use the script since it always threw an error because of the Row attribute was empty.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested it in our Veeam environment.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/54741566/148654234-0b8c2e96-0b03-445d-a826-f68a12cacd13.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
