### PR TITLE
Add option to set veeam custom tcp port

### DIFF
--- a/AsBuiltreport.Veeam.VBR.json
+++ b/AsBuiltreport.Veeam.VBR.json
@@ -9,7 +9,7 @@
         "ShowTableCaptions": true
     },
     "Options": {
-
+        "BackupServerPort": 9392
     },
     "InfoLevel": {
 		"_comment_": "Please refer to the AsBuiltReport project contributing guide for information about how to define InfoLevels.",

--- a/Src/Private/Get-AbrVbrServerConnection.ps1
+++ b/Src/Private/Get-AbrVbrServerConnection.ps1
@@ -4,7 +4,7 @@ function Get-AbrVbrServerConnection {
     Used by As Built Report to establish conection to Veeam B&R Server.
     .DESCRIPTION
     .NOTES
-        Version:        0.1.0
+        Version:        0.3.1
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -17,7 +17,7 @@ function Get-AbrVbrServerConnection {
     )
 
     begin {
-        Write-PscriboMessage "Establishing the initial connection to the Backup Server: $($System)."
+        Write-PscriboMessage "Establishing initial connection to Backup Server: $($System)."
     }
 
     process {
@@ -30,12 +30,12 @@ function Get-AbrVbrServerConnection {
         elseif ($null -eq $OpenConnection) {
             Write-PScriboMessage "No existing veeam server connection found"
             try {
-                Write-PScriboMessage "Connecting to $($System) with provided credentials"
-                Connect-VBRServer -Server $System -Credential $Credential
+                Write-PScriboMessage "Connecting to $($System) with $($Credential.USERNAME) credentials"
+                Connect-VBRServer -Server $System -Credential $Credential -Port $Options.BackupServerPort
             }
             catch {
                 Write-PscriboMessage -IsWarning $_.Exception.Message
-                Throw "Failed to connect to Veeam B&R Host '$System' with user '$env:USERNAME'"
+                Throw "Failed to connect to Veeam Backup Server Host $($System):$($Options.BackupServerPort) with username $($Credential.USERNAME)"
             }
         }
         else {
@@ -43,21 +43,21 @@ function Get-AbrVbrServerConnection {
             Disconnect-VBRServer
             try {
                 Write-PScriboMessage "Trying to open a new connection to $($System)"
-                Connect-VBRServer -Server $System -Credential $Credential
+                Connect-VBRServer -Server $System -Credential $Credential -Port $Options.BackupServerPort
             }
             catch {
                 Write-PscriboMessage -IsWarning $_.Exception.Message
-                Throw "Failed to connect to Veeam B&R Host '$System' with user '$env:USERNAME'"
+                Throw "Failed to connect to Veeam Backup Server Host $($System):$($Options.BackupServerPort) with username $($Credential.USERNAME)"
             }
         }
         Write-PScriboMessage "Validating connection to $($System)"
         $NewConnection = (Get-VBRServerSession).Server
         if ($null -eq $NewConnection) {
             Write-PscriboMessage -IsWarning $_.Exception.Message
-            Throw "Failed to connect to Veeam BR Host '$System' with user '$env:USERNAME'"
+            Throw "Failed to connect to Veeam Backup Server Host $($System):$($Options.BackupServerPort) with username $($Credential.USERNAME)"
         }
         elseif ($NewConnection) {
-            Write-PScriboMessage "Successfully connected to $($System) VBR Server."
+            Write-PScriboMessage "Successfully connected to $($System):$($Options.BackupServerPort) Backup Server."
         }
     }
     end {}


### PR DESCRIPTION
## Description

Currently the veeam report does not provide an option for the user to specify the tcp port to be used to connect to the backup server.
Add a variable to the json file that allows specifying a custom tcp port.

## Related Issue

- Fixes #17

## How Has This Been Tested?

- HomeLab

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
